### PR TITLE
Add type "completion" in field.FIELDS

### DIFF
--- a/elasticsearch_dsl/field.py
+++ b/elasticsearch_dsl/field.py
@@ -132,6 +132,7 @@ FIELDS = (
     'attachment',
     'geo_point',
     'geo_shape',
+    'completion',
 )
 
 # generate the query classes dynamicaly


### PR DESCRIPTION
According to the http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-suggesters-completion.html we must create field with type 'completion' in order to use Suggesters