### PR TITLE
Added a highlight dictionary to DocType.meta (closes #62)

### DIFF
--- a/elasticsearch_dsl/document.py
+++ b/elasticsearch_dsl/document.py
@@ -120,6 +120,8 @@ class DocType(ObjectBase):
     def from_es(cls, hit):
         # don't modify in place
         meta = hit.copy()
+        # make sure highlighting information ends up in meta
+        meta['_highlight'] = meta.pop('highlight', {})
         doc = meta.pop('_source')
         return cls(meta=meta, **doc)
 


### PR DESCRIPTION
Massaging the hit data slightly in `from_es` seemed cleaner than changing the `k.startswith('_')` check to also allow a non-underscored key.